### PR TITLE
refactor(proof): 대기중인 인증 조회 응답 스펙 변경

### DIFF
--- a/src/main/java/me/jinjjahalgae/domain/proof/mapper/ProofMapper.java
+++ b/src/main/java/me/jinjjahalgae/domain/proof/mapper/ProofMapper.java
@@ -105,14 +105,21 @@ public class ProofMapper {
      * @return {@link ProofAwaitResponse}
      */
     public static ProofAwaitResponse toAwaitResponse(Proof proof) {
-        String imageKey = proof.getProofImages().stream()
-                .filter(img -> img.getIndex() == 1)
-                .findFirst()
-                .map(ProofImage::getImageKey)
-                .orElse(null);
+        String firstImageKey = null;
+        String secondImageKey = null;
+        String thirdImageKey = null;
 
+        for (ProofImage proofImage : proof.getProofImages()) {
+            switch (proofImage.getIndex()) {
+                case 1 -> firstImageKey = proofImage.getImageKey();
+                case 2 -> secondImageKey = proofImage.getImageKey();
+                case 3 -> thirdImageKey = proofImage.getImageKey();
+            }
+        }
         return new ProofAwaitResponse(
-                imageKey,
+                firstImageKey,
+                secondImageKey,
+                thirdImageKey,
                 proof.getComment(),
                 proof.getCreatedAt(),
                 proof.getStatus(),

--- a/src/main/java/me/jinjjahalgae/domain/proof/usecase/get/await/dto/ProofAwaitResponse.java
+++ b/src/main/java/me/jinjjahalgae/domain/proof/usecase/get/await/dto/ProofAwaitResponse.java
@@ -13,7 +13,9 @@ import java.time.LocalDateTime;
         description = "승인 대기중인 인증 조회 응답 DTO",
         example = """
         {
-          "imageKey": "1234abcd-5678-efgh-ijkl-9012mnopqrst.jpg",
+          "firstImageKey": "1234abcd-5678-efgh-ijkl-9012mnopqrst.jpg",
+          "secondImageKey": "3433abcd-5678-efgh-ijkl-9012mnopqrst.jpg",
+          "thirdImageKey": null,
           "comment": "6시에 헬스장 가서 7시30분까지 운동했습니다.",
           "createdAt": "2025-07-09T13:30:00+09:00",
           "status": "APPROVE_PENDING",
@@ -23,8 +25,14 @@ import java.time.LocalDateTime;
         """
 )
 public record ProofAwaitResponse(
-        @Schema(description = "1 번째 이미지 (대표 사진) 키")
-        String imageKey,
+        @Schema(description = "1 번째 이미지 (대표 사진) 키 - 카드 형태에서 출력")
+        String firstImageKey,
+
+        @Schema(description = "2 번째 이미지 (대표 사진) 키 - 카드를 누르는 경우 상세 모달에서만 출력")
+        String secondImageKey,
+
+        @Schema(description = "3 번째 이미지 (대표 사진) 키 - 카드를 누르는 경우 상세 모달에서만 출력")
+        String thirdImageKey,
 
         @Schema(description = "인증 코멘트 (없으면 null)")
         String comment,

--- a/src/main/java/me/jinjjahalgae/presentation/api/docs/proof/ProofControllerDocs.java
+++ b/src/main/java/me/jinjjahalgae/presentation/api/docs/proof/ProofControllerDocs.java
@@ -317,7 +317,9 @@ public interface ProofControllerDocs {
                                       "success": true,
                                       "result": [
                                         {
-                                          "titleImageKey": "1234abcd-5678-efgh-ijkl-9012mnopqrst.jpg",
+                                          "firstImageKey": "1234abcd-5678-efgh-ijkl-9012mnopqrst.jpg",
+                                          "secondImageKey": null,
+                                          "thirdImageKey": null,
                                           "comment": "6시에 헬스장 가서 7시30분까지 운동했습니다.",
                                           "createdAt": "2025-07-09T19:30:00+09:00",
                                           "status": "APPROVE_PENDING",
@@ -325,7 +327,9 @@ public interface ProofControllerDocs {
                                           "proofId": 11
                                         },
                                         {
-                                          "titleImageKey": "3453abcd-5678-efgh-ijkl-9012mnopqrst.jpg",
+                                          "firstImageKey": "3453abcd-5678-efgh-ijkl-9012mnopqrst.jpg",
+                                          "secondImageKey": "1134abcd-5678-efgh-ijkl-9012mnopqrst.jpg",
+                                          "thirdImageKey": "4567abcd-5678-efgh-ijkl-9012mnopqrst.jpg",
                                           "comment": "6시에 헬스장 가서 7시30분까지 운동했습니다.",
                                           "createdAt": "2025-07-08T19:30:00+09:00",
                                           "status": "APPROVE_PENDING",


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

### 대기중인 인증 조회 
- dto 응답 스펙 변경
- swagger 응답 명세 수정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

-   [ ] 새로운 기능 추가
-   [ ] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [x] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

### 대기 중인 인증 응답 스펙 변경
- 기존 대표 사진 이미지 키만 넣어 보내는 방식에서 모든 이미지 키를 다 넣어 보내는 방식으로 변경

### 변경 이유
- 기존은 대기 중인 인증 카드를 누르는 경우 인증 상세를 호출하게 될 거라 생각하고 대표 사진만 넣어서 보내게 응답을 정의
- 대기 중인 피드백은 감독자가 누르는 것으로 대기 중인 피드백을 누르는 경우 감독자는 다른 감독자의 피드백을 볼 수 없게 되어 있음
- 인증 상세 응답에는 모든 피드백 정보가 들어있기 때문에 대기 중인 카드를 눌렀을 때 인증 상세로 넘어가면 안됨
- 인증 이미지 키를 모두 응답으로 보내 대기 중인 카드를 누르는 경우 추가 api 호출 없이 모든 이미지를 모달에서 출력하도록 스펙 변경

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
-   [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
-   [ ] 릴리즈 노트를 갱신했습니다.
