### PR TITLE
feat(invite): 감독 참여, 철회, 포기 시 알림 전송, 초대 정보를 계약 취소 시 삭제

### DIFF
--- a/src/main/java/me/jinjjahalgae/domain/contract/usecase/delete/CancelContractUseCaseImpl.java
+++ b/src/main/java/me/jinjjahalgae/domain/contract/usecase/delete/CancelContractUseCaseImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import me.jinjjahalgae.domain.contract.entity.Contract;
 import me.jinjjahalgae.domain.contract.repository.ContractRepository;
 import me.jinjjahalgae.global.exception.ErrorCode;
+import me.jinjjahalgae.global.storage.redis.usecase.invite.delete.DeleteInviteInfoUseCaseImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CancelContractUseCaseImpl implements CancelContractUseCase {
 
     private final ContractRepository contractRepository;
+    private final DeleteInviteInfoUseCaseImpl deleteInviteInfoUseCase;
 
     @Override
     @Transactional
@@ -27,5 +29,8 @@ public class CancelContractUseCaseImpl implements CancelContractUseCase {
         //계약이 시작했는가 (계약 취소는 대기 상태에서만 가능) + 그렇다면 취소 및 삭제
         contract.cancel();
         contractRepository.delete(contract);
+
+        //남아있는 초대 정보 삭제
+        deleteInviteInfoUseCase.execute(contractId);
     }
 }

--- a/src/main/java/me/jinjjahalgae/domain/participation/usecase/create/supervisor/CreateSupervisorParticipationUseCaseImpl.java
+++ b/src/main/java/me/jinjjahalgae/domain/participation/usecase/create/supervisor/CreateSupervisorParticipationUseCaseImpl.java
@@ -3,6 +3,8 @@ package me.jinjjahalgae.domain.participation.usecase.create.supervisor;
 import lombok.RequiredArgsConstructor;
 import me.jinjjahalgae.domain.contract.entity.Contract;
 import me.jinjjahalgae.domain.contract.repository.ContractRepository;
+import me.jinjjahalgae.domain.notification.enums.NotificationType;
+import me.jinjjahalgae.domain.notification.usecase.listener.event.NotificationEvent;
 import me.jinjjahalgae.domain.participation.repository.ParticipationRepository;
 import me.jinjjahalgae.domain.participation.usecase.create.contractor.dto.CreateContractorParticipationRequest;
 import me.jinjjahalgae.domain.participation.entity.Participation;
@@ -10,6 +12,7 @@ import me.jinjjahalgae.domain.participation.enums.Role;
 import me.jinjjahalgae.domain.user.User;
 import me.jinjjahalgae.global.exception.ErrorCode;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,9 +20,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class CreateSupervisorParticipationUseCaseImpl implements CreateSupervisorParticipationUseCase {
-    private final ParticipationRepository participationRepository;
-    private final ContractRepository contractRepository;
+
     private final RedisTemplate<String, Object> redisTemplate;
+    private final ContractRepository contractRepository;
+    private final ParticipationRepository participationRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Value("${spring.data.redis.contract-supervisors}")
     private String SUPERVISOR_COUNT_PREFIX;
@@ -62,6 +67,13 @@ public class CreateSupervisorParticipationUseCaseImpl implements CreateSuperviso
 
         // 계약에 참여 정보 추가 및 감독자 수 증가
         contract.addParticipation(newParticipation);
+
+        // 감독자 참여 알림 전송
+        eventPublisher.publishEvent(new NotificationEvent(
+                NotificationType.SUPERVISOR_ADDED,
+                contractId,
+                user.getId()
+        ));
 
         // redis의 해당 계약 감독자 자리 감소
         redisTemplate.opsForValue().decrement(supervisorCountKey); // decr 연산으로 원자성 보장

--- a/src/main/java/me/jinjjahalgae/domain/participation/usecase/delete/supervisor/DeleteSupervisorParticipationUseCaseImpl.java
+++ b/src/main/java/me/jinjjahalgae/domain/participation/usecase/delete/supervisor/DeleteSupervisorParticipationUseCaseImpl.java
@@ -4,11 +4,14 @@ import lombok.RequiredArgsConstructor;
 import me.jinjjahalgae.domain.contract.entity.Contract;
 import me.jinjjahalgae.domain.contract.enums.ContractStatus;
 import me.jinjjahalgae.domain.contract.repository.ContractRepository;
+import me.jinjjahalgae.domain.notification.enums.NotificationType;
+import me.jinjjahalgae.domain.notification.usecase.listener.event.NotificationEvent;
 import me.jinjjahalgae.domain.participation.entity.Participation;
 import me.jinjjahalgae.domain.participation.enums.Role;
 import me.jinjjahalgae.domain.user.User;
 import me.jinjjahalgae.global.exception.ErrorCode;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +22,7 @@ public class DeleteSupervisorParticipationUseCaseImpl implements DeleteSuperviso
 
     private final ContractRepository contractRepository;
     private final RedisTemplate<String, Object> redisTemplate;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Value("${spring.data.redis.contract-supervisors}")
     private String SUPERVISOR_COUNT_PREFIX;
@@ -44,6 +48,13 @@ public class DeleteSupervisorParticipationUseCaseImpl implements DeleteSuperviso
 
         // 감독자의 참여 정보 제거
         contract.removeParticipation(supervisorParticipation);
+
+        // 감독자 포기 알림 전송
+        eventPublisher.publishEvent(new NotificationEvent(
+                NotificationType.SUPERVISOR_WITHDRAWN,
+                contractId,
+                user.getId()
+        ));
 
         // redis의 해당 계약 감독자 자리 증가
         String supervisorCountKey = SUPERVISOR_COUNT_PREFIX + contract.getId();

--- a/src/main/java/me/jinjjahalgae/domain/participation/usecase/patch/supervisor/PatchSupervisorParticipationUseCaseImpl.java
+++ b/src/main/java/me/jinjjahalgae/domain/participation/usecase/patch/supervisor/PatchSupervisorParticipationUseCaseImpl.java
@@ -4,10 +4,13 @@ import lombok.RequiredArgsConstructor;
 import me.jinjjahalgae.domain.contract.entity.Contract;
 import me.jinjjahalgae.domain.contract.enums.ContractStatus;
 import me.jinjjahalgae.domain.contract.repository.ContractRepository;
+import me.jinjjahalgae.domain.notification.enums.NotificationType;
+import me.jinjjahalgae.domain.notification.usecase.listener.event.NotificationEvent;
 import me.jinjjahalgae.domain.participation.entity.Participation;
 import me.jinjjahalgae.domain.participation.enums.Role;
 import me.jinjjahalgae.domain.user.User;
 import me.jinjjahalgae.global.exception.ErrorCode;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PatchSupervisorParticipationUseCaseImpl implements PatchSupervisorParticipationUseCase {
 
     private final ContractRepository contractRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     @Transactional
@@ -41,6 +45,13 @@ public class PatchSupervisorParticipationUseCaseImpl implements PatchSupervisorP
 
         // 총 감독자 수 1 감소
         contract.decrementTotalSupervisor();
+
+        // 감독자 포기 알림 전송
+        eventPublisher.publishEvent(new NotificationEvent(
+                NotificationType.SUPERVISOR_WITHDRAWN,
+                contractId,
+                user.getId()
+        ));
     }
 
 }


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 감독 참여, 철회, 포기 시 알림 이벤트를 발행하게 했습니다.
- 계약 취소(시작 전)시 redis에 남아있는 초대 정보를 삭제하는 로직을 추가했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

-   [x] 새로운 기능 추가
-   [ ] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
-   [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
-   [ ] 릴리즈 노트를 갱신했습니다.
