### PR TITLE
feature(oneoff): 단일 계약 관련 로직 구현

### DIFF
--- a/src/main/java/me/jinjjahalgae/domain/contract/repository/ContractRepository.java
+++ b/src/main/java/me/jinjjahalgae/domain/contract/repository/ContractRepository.java
@@ -7,11 +7,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -33,14 +31,64 @@ public interface ContractRepository extends JpaRepository<Contract, Long> {
     boolean existsByIdAndStatus(Long id, ContractStatus status);
 
     // 시작일로 대기중 계약 조회
-    @Query("SELECT c FROM Contract c WHERE c.status = :status AND FUNCTION('DATE', c.startDate) = :date")
-    List<Contract> findByStatusAndStartDateOn(@Param("status") ContractStatus status, @Param("date") LocalDate date);
+    @Query("SELECT c FROM Contract c WHERE c.status = :status AND FUNCTION('DATE', c.startDate) = :date AND c.oneOff = :oneOff")
+    List<Contract> findByStatusAndStartDateOnAndOneOff(@Param("status") ContractStatus status, @Param("date") LocalDate date, @Param("oneOff") boolean oneOff);
 
     // 종료일로 진행중 계약 조회
-    @Query("SELECT c FROM Contract c WHERE c.status = :status AND FUNCTION('DATE', c.endDate) = :date")
-    List<Contract> findByStatusAndEndDateOn(@Param("status") ContractStatus status, @Param("date") LocalDate date);
+    @Query("SELECT c FROM Contract c WHERE c.status = :status AND FUNCTION('DATE', c.endDate) = :date AND c.oneOff = :oneOff")
+    List<Contract> findByStatusAndEndDateOnAndOneOff(@Param("status") ContractStatus status, @Param("date") LocalDate date, @Param("oneOff") boolean oneOff);
 
     // 계약 조회 시 관련한 유저 정보도 한번에
     @Query("SELECT c FROM Contract c JOIN FETCH c.user WHERE c.id = :contractId")
     Optional<Contract> findByIdWithUser(@Param("contractId") Long contractId);
+
+    // 생성된 지 24시간이 지났고 서명한 감독자가 한 명도 없고 PENDING 상태의 단건 계약 목록 조회
+    @Query("""
+        select c
+        from Contract c
+        join fetch c.user
+        where c.oneOff = true
+            and c.status = 'PENDING'
+            and c.createdAt <= :date
+            and not exists
+                (select p
+                from Participation p
+                where p.contract = c and p.role = 'SUPERVISOR')
+    """)
+    List<Contract> findExpiredOneOffContractsWithNoSupervisors(@Param("date") LocalDateTime date);
+
+    // 시작된 지 24시간이 지났고 인증이 하나 이상 존재하고 피드백이 하나라도 없는 진행중인 단건 계약 목록 조회
+    @Query("""
+        select c from Contract c
+        join fetch c.user
+        where c.oneOff = true
+          and c.status = 'IN_PROGRESS'
+          and c.startDate <= :date
+          and exists
+              (select 1
+              from Proof p
+              where p.contractId = c.id)
+          and not exists
+              (select 1
+                from Feedback f
+                where f.proof.id in (
+                    select p.id
+                    from Proof p
+                    where p.contractId = c.id))
+    """)
+    List<Contract> findCompletableOneOffContracts(@Param("date") LocalDateTime date);
+
+    // 시작된 지 24시간이 지났고 인증이 하나도 없고 진행중인 단건 계약 목록 조회
+    @Query("""
+        select c from Contract c
+        join fetch c.user
+        where c.oneOff = true
+          and c.status = 'IN_PROGRESS'
+          and c.startDate <= :date
+          and not exists
+              (select 1
+              from Proof p
+              where p.contractId = c.id)
+    """)
+    List<Contract> findFailableOneOffContracts(@Param("date") LocalDateTime date);
 }

--- a/src/main/java/me/jinjjahalgae/domain/contract/scheduler/ContractScheduler.java
+++ b/src/main/java/me/jinjjahalgae/domain/contract/scheduler/ContractScheduler.java
@@ -9,8 +9,6 @@ import me.jinjjahalgae.domain.notification.usecase.create.CreateNotificationUseC
 import me.jinjjahalgae.domain.notification.usecase.create.dto.NotificationCreateRequest;
 import me.jinjjahalgae.global.storage.redis.usecase.invite.delete.DeleteInviteInfoUseCase;
 import me.jinjjahalgae.global.storage.redis.usecase.invite.get.GetJoinedSupervisorsUseCase;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,12 +25,12 @@ public class ContractScheduler {
     private final CreateNotificationUseCase createNotificationUseCase;
     private final GetJoinedSupervisorsUseCase getJoinedSupervisorsUseCase;
 
+    // 시작일로 대기중인 기본계약(oneOff=false) 목록 조회
     @Scheduled(cron = "0 1 0 * * *")
     @Transactional
     public void startContracts() {
-        // 시작일로 대기중 계약 목록 조회
         LocalDate today = LocalDate.now();
-        List<Contract> pendingContracts = contractRepository.findByStatusAndStartDateOn(ContractStatus.PENDING, today);
+        List<Contract> pendingContracts = contractRepository.findByStatusAndStartDateOnAndOneOff(ContractStatus.PENDING, today, false);
 
         if (pendingContracts.isEmpty()) {
             return;
@@ -53,12 +51,13 @@ public class ContractScheduler {
         }
     }
 
+    // 종료일로 진행중인 기본계약(oneOff=false) 목록 조회
     @Scheduled(cron = "0 59 23 * * *")
     @Transactional
     public void endContracts() {
-        // 종료일로 진행중 계약 목록 조회
         LocalDate today = LocalDate.now();
-        List<Contract> progressingContracts = contractRepository.findByStatusAndEndDateOn(ContractStatus.IN_PROGRESS, today);
+        
+        List<Contract> progressingContracts = contractRepository.findByStatusAndEndDateOnAndOneOff(ContractStatus.IN_PROGRESS, today, false);
 
         if (progressingContracts.isEmpty()) {
             return;

--- a/src/main/java/me/jinjjahalgae/domain/contract/scheduler/OneOffContractScheduler.java
+++ b/src/main/java/me/jinjjahalgae/domain/contract/scheduler/OneOffContractScheduler.java
@@ -1,0 +1,32 @@
+package me.jinjjahalgae.domain.contract.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import me.jinjjahalgae.domain.contract.usecase.process.EndOneOffContractUseCase;
+import me.jinjjahalgae.domain.contract.usecase.process.VerifyOneOffContractSignatureUseCase;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class OneOffContractScheduler {
+
+    private final EndOneOffContractUseCase endOneOffContractUseCase;
+    private final VerifyOneOffContractSignatureUseCase verifyOneOffContractSignatureUseCase;
+
+    /**
+     * 5분마다 실행되는 스케줄러 (단건 스케쥴러)
+     *
+     * - 단건 계약 24시간 체크
+     * - 단건 계약 서명검증
+     */
+    @Scheduled(cron = "0 */5 * * * *")
+    @Transactional
+    public void processOneOffContracts() {
+        // 단건 계약 24시간 체크
+        endOneOffContractUseCase.execute();
+        
+        // 단건 계약 서명검증
+        verifyOneOffContractSignatureUseCase.execute();
+    }
+} 

--- a/src/main/java/me/jinjjahalgae/domain/contract/usecase/process/EndOneOffContractUseCase.java
+++ b/src/main/java/me/jinjjahalgae/domain/contract/usecase/process/EndOneOffContractUseCase.java
@@ -1,0 +1,5 @@
+package me.jinjjahalgae.domain.contract.usecase.process;
+
+public interface EndOneOffContractUseCase {
+    void execute();
+} 

--- a/src/main/java/me/jinjjahalgae/domain/contract/usecase/process/EndOneOffContractUseCaseImpl.java
+++ b/src/main/java/me/jinjjahalgae/domain/contract/usecase/process/EndOneOffContractUseCaseImpl.java
@@ -1,0 +1,56 @@
+package me.jinjjahalgae.domain.contract.usecase.process;
+
+import lombok.RequiredArgsConstructor;
+import me.jinjjahalgae.domain.contract.entity.Contract;
+import me.jinjjahalgae.domain.contract.repository.ContractRepository;
+import me.jinjjahalgae.domain.notification.enums.NotificationType;
+import me.jinjjahalgae.domain.notification.usecase.create.CreateNotificationUseCase;
+import me.jinjjahalgae.domain.notification.usecase.create.dto.NotificationCreateRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class EndOneOffContractUseCaseImpl implements EndOneOffContractUseCase {
+
+    private final ContractRepository contractRepository;
+    private final CreateNotificationUseCase createNotificationUseCase;
+
+    /**
+     * 단건 계약(oneOff=true)이 시작되고 24시간이 지났는지 확인하고 계약 상태를 결정합니다.
+     * - 인증을 올렸는데 계약이 생성된지 24시간이 지난 후에도 피드백이 없으면 계약 성공
+     * - 인증을 안올리고 계약이 생성된지 24시간이 지나면 계약 실패
+     */
+    @Override
+    public void execute() {
+        LocalDateTime deadline = LocalDateTime.now().minusHours(24);
+
+        // 성공 처리 대상 계약들 처리
+        List<Contract> completableContracts = contractRepository.findCompletableOneOffContracts(deadline);
+
+        for (Contract contract : completableContracts) {
+            contract.complete();
+
+            // 계약 성공 알림 발송
+            createNotificationUseCase.execute(
+                    new NotificationCreateRequest(NotificationType.CONTRACT_ENDED_SUCCESS, contract.getId(), contract.getUser().getId())
+            );
+        }
+
+        // 실패 처리 대상 계약들 처리
+        List<Contract> failableContracts = contractRepository.findFailableOneOffContracts(deadline);
+
+        for (Contract contract : failableContracts) {
+            contract.fail();
+
+            // 계약 실패 알림 발송
+            createNotificationUseCase.execute(
+                    new NotificationCreateRequest(NotificationType.CONTRACT_ENDED_FAIL, contract.getId(), contract.getUser().getId())
+            );
+        }
+    }
+} 

--- a/src/main/java/me/jinjjahalgae/domain/contract/usecase/process/EndOneOffContractUseCaseImpl.java
+++ b/src/main/java/me/jinjjahalgae/domain/contract/usecase/process/EndOneOffContractUseCaseImpl.java
@@ -4,8 +4,8 @@ import lombok.RequiredArgsConstructor;
 import me.jinjjahalgae.domain.contract.entity.Contract;
 import me.jinjjahalgae.domain.contract.repository.ContractRepository;
 import me.jinjjahalgae.domain.notification.enums.NotificationType;
-import me.jinjjahalgae.domain.notification.usecase.create.CreateNotificationUseCase;
-import me.jinjjahalgae.domain.notification.usecase.create.dto.NotificationCreateRequest;
+import me.jinjjahalgae.domain.notification.usecase.listener.event.NotificationEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,7 +18,7 @@ import java.util.List;
 public class EndOneOffContractUseCaseImpl implements EndOneOffContractUseCase {
 
     private final ContractRepository contractRepository;
-    private final CreateNotificationUseCase createNotificationUseCase;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 단건 계약(oneOff=true)이 시작되고 24시간이 지났는지 확인하고 계약 상태를 결정합니다.
@@ -35,9 +35,9 @@ public class EndOneOffContractUseCaseImpl implements EndOneOffContractUseCase {
         for (Contract contract : completableContracts) {
             contract.complete();
 
-            // 계약 성공 알림 발송
-            createNotificationUseCase.execute(
-                    new NotificationCreateRequest(NotificationType.CONTRACT_ENDED_SUCCESS, contract.getId(), contract.getUser().getId())
+            // 계약 성공 알림 이벤트 발행
+            eventPublisher.publishEvent(
+                new NotificationEvent(NotificationType.CONTRACT_ENDED_SUCCESS, contract.getId(), contract.getUser().getId())
             );
         }
 
@@ -47,9 +47,9 @@ public class EndOneOffContractUseCaseImpl implements EndOneOffContractUseCase {
         for (Contract contract : failableContracts) {
             contract.fail();
 
-            // 계약 실패 알림 발송
-            createNotificationUseCase.execute(
-                    new NotificationCreateRequest(NotificationType.CONTRACT_ENDED_FAIL, contract.getId(), contract.getUser().getId())
+            // 계약 실패 알림 이벤트 발행
+            eventPublisher.publishEvent(
+                new NotificationEvent(NotificationType.CONTRACT_ENDED_FAIL, contract.getId(), contract.getUser().getId())
             );
         }
     }

--- a/src/main/java/me/jinjjahalgae/domain/contract/usecase/process/VerifyOneOffContractSignatureUseCase.java
+++ b/src/main/java/me/jinjjahalgae/domain/contract/usecase/process/VerifyOneOffContractSignatureUseCase.java
@@ -1,0 +1,5 @@
+package me.jinjjahalgae.domain.contract.usecase.process;
+
+public interface VerifyOneOffContractSignatureUseCase {
+    void execute();
+} 

--- a/src/main/java/me/jinjjahalgae/domain/contract/usecase/process/VerifyOneOffContractSignatureUseCaseImpl.java
+++ b/src/main/java/me/jinjjahalgae/domain/contract/usecase/process/VerifyOneOffContractSignatureUseCaseImpl.java
@@ -1,0 +1,50 @@
+package me.jinjjahalgae.domain.contract.usecase.process;
+
+import lombok.RequiredArgsConstructor;
+import me.jinjjahalgae.domain.contract.entity.Contract;
+import me.jinjjahalgae.domain.contract.repository.ContractRepository;
+import me.jinjjahalgae.domain.notification.enums.NotificationType;
+import me.jinjjahalgae.domain.notification.usecase.create.CreateNotificationUseCase;
+import me.jinjjahalgae.domain.notification.usecase.create.dto.NotificationCreateRequest;
+import me.jinjjahalgae.global.storage.redis.usecase.invite.delete.DeleteInviteInfoUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class VerifyOneOffContractSignatureUseCaseImpl implements VerifyOneOffContractSignatureUseCase {
+
+    private final ContractRepository contractRepository;
+    private final DeleteInviteInfoUseCase deleteInviteInfoUseCase;
+    private final CreateNotificationUseCase createNotificationUseCase;
+
+    /**
+     * 단건 계약(oneOff=true)의 서명을 검증합니다
+     * 계약이 생성된 후 24시간 내에 1명이라도 감독자가 서명하지 않은 계약은 삭제됩니다.
+     */
+    @Override
+    public void execute() {
+        // 24시간 전을 마감 시간으로 설정
+        LocalDateTime deadline = LocalDateTime.now().minusHours(24);
+
+        // 감독자 서명안된 단건 계약 조회
+        List<Contract> contractsToDelete = contractRepository.findExpiredOneOffContractsWithNoSupervisors(deadline);
+
+        for (Contract contract : contractsToDelete) {
+            // 조회된 모든 감독자 서명안된 단건 계약을 삭제
+            contractRepository.delete(contract);
+
+            // 자동 삭제 알림 전송
+            createNotificationUseCase.execute(
+                    new NotificationCreateRequest(NotificationType.CONTRACT_AUTO_DELETED, contract.getId(), contract.getUser().getId())
+            );
+
+            // 초대 정보 삭제
+            deleteInviteInfoUseCase.execute(contract.getId());
+        }
+    }
+} 

--- a/src/main/java/me/jinjjahalgae/domain/contract/usecase/process/VerifyOneOffContractSignatureUseCaseImpl.java
+++ b/src/main/java/me/jinjjahalgae/domain/contract/usecase/process/VerifyOneOffContractSignatureUseCaseImpl.java
@@ -4,9 +4,9 @@ import lombok.RequiredArgsConstructor;
 import me.jinjjahalgae.domain.contract.entity.Contract;
 import me.jinjjahalgae.domain.contract.repository.ContractRepository;
 import me.jinjjahalgae.domain.notification.enums.NotificationType;
-import me.jinjjahalgae.domain.notification.usecase.create.CreateNotificationUseCase;
-import me.jinjjahalgae.domain.notification.usecase.create.dto.NotificationCreateRequest;
+import me.jinjjahalgae.domain.notification.usecase.listener.event.NotificationEvent;
 import me.jinjjahalgae.global.storage.redis.usecase.invite.delete.DeleteInviteInfoUseCase;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,7 +20,7 @@ public class VerifyOneOffContractSignatureUseCaseImpl implements VerifyOneOffCon
 
     private final ContractRepository contractRepository;
     private final DeleteInviteInfoUseCase deleteInviteInfoUseCase;
-    private final CreateNotificationUseCase createNotificationUseCase;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 단건 계약(oneOff=true)의 서명을 검증합니다
@@ -38,9 +38,9 @@ public class VerifyOneOffContractSignatureUseCaseImpl implements VerifyOneOffCon
             // 조회된 모든 감독자 서명안된 단건 계약을 삭제
             contractRepository.delete(contract);
 
-            // 자동 삭제 알림 전송
-            createNotificationUseCase.execute(
-                    new NotificationCreateRequest(NotificationType.CONTRACT_AUTO_DELETED, contract.getId(), contract.getUser().getId())
+            // 자동 삭제 알림 이벤트 발행
+            eventPublisher.publishEvent(
+                new NotificationEvent(NotificationType.CONTRACT_AUTO_DELETED, contract.getId(), contract.getUser().getId())
             );
 
             // 초대 정보 삭제

--- a/src/main/java/me/jinjjahalgae/domain/feedback/usecase/create/CreateFeedbackUseCaseImpl.java
+++ b/src/main/java/me/jinjjahalgae/domain/feedback/usecase/create/CreateFeedbackUseCaseImpl.java
@@ -14,6 +14,8 @@ import me.jinjjahalgae.global.exception.ErrorCode;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import me.jinjjahalgae.domain.notification.enums.NotificationType;
+import me.jinjjahalgae.domain.notification.usecase.listener.event.NotificationEvent;
 
 @Service
 @RequiredArgsConstructor
@@ -60,6 +62,13 @@ public class CreateFeedbackUseCaseImpl implements CreateFeedbackUseCase {
         if (isAllSupervisorsChecked) {
             eventPublisher.publishEvent(new HandleProofEvent(proof.getId()));
         }
+
+        // 피드백 추가 알림 이벤트 발행
+        eventPublisher.publishEvent(new NotificationEvent(
+            NotificationType.FEEDBACK_ADDED,
+            proof.getContractId(),
+            userId
+        ));
     }
 
     // 유효한 감독자 권한이 존재하는지 검사

--- a/src/main/java/me/jinjjahalgae/domain/participation/usecase/create/supervisor/CreateSupervisorParticipationUseCaseImpl.java
+++ b/src/main/java/me/jinjjahalgae/domain/participation/usecase/create/supervisor/CreateSupervisorParticipationUseCaseImpl.java
@@ -3,12 +3,16 @@ package me.jinjjahalgae.domain.participation.usecase.create.supervisor;
 import lombok.RequiredArgsConstructor;
 import me.jinjjahalgae.domain.contract.entity.Contract;
 import me.jinjjahalgae.domain.contract.repository.ContractRepository;
+import me.jinjjahalgae.domain.notification.enums.NotificationType;
+import me.jinjjahalgae.domain.notification.usecase.create.CreateNotificationUseCase;
+import me.jinjjahalgae.domain.notification.usecase.create.dto.NotificationCreateRequest;
 import me.jinjjahalgae.domain.participation.repository.ParticipationRepository;
 import me.jinjjahalgae.domain.participation.usecase.common.dto.ParticipationCreateRequest;
 import me.jinjjahalgae.domain.participation.entity.Participation;
 import me.jinjjahalgae.domain.participation.enums.Role;
 import me.jinjjahalgae.domain.user.User;
 import me.jinjjahalgae.global.exception.ErrorCode;
+import me.jinjjahalgae.global.storage.redis.usecase.invite.delete.DeleteInviteInfoUseCase;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -20,6 +24,9 @@ public class CreateSupervisorParticipationUseCaseImpl implements CreateSuperviso
     private final ParticipationRepository participationRepository;
     private final ContractRepository contractRepository;
     private final RedisTemplate<String, Object> redisTemplate;
+
+    private final CreateNotificationUseCase createNotificationUseCase;
+    private final DeleteInviteInfoUseCase deleteInviteInfoUseCase;
 
     @Value("${spring.data.redis.contract-supervisors}")
     private String SUPERVISOR_COUNT_PREFIX;
@@ -65,5 +72,19 @@ public class CreateSupervisorParticipationUseCaseImpl implements CreateSuperviso
 
         // redis의 해당 계약 감독자 자리 감소
         redisTemplate.opsForValue().decrement(supervisorCountKey); // decr 연산으로 원자성 보장
+
+        // 만약 단발성 계약이면 바로 시작처리
+        if (contract.isOneOff()) {
+            // 감독자 수를 1로 설정하고 계약 시작
+            contract.start(1);
+
+            // 계약 시작 알림 발송
+            createNotificationUseCase.execute(
+                    new NotificationCreateRequest(NotificationType.CONTRACT_STARTED, contract.getId(), contract.getUser().getId())
+            );
+
+            // 초대 정보 삭제
+            deleteInviteInfoUseCase.execute(contract.getId());
+        }
     }
 }

--- a/src/main/java/me/jinjjahalgae/domain/proof/entities/Proof.java
+++ b/src/main/java/me/jinjjahalgae/domain/proof/entities/Proof.java
@@ -122,4 +122,9 @@ public class Proof extends BaseEntity {
     private void reject(){
         this.status = ProofStatus.REJECTED;
     }
+
+    // 인증 상태가 APPROVED 인지
+    public boolean isApproved() {
+        return this.status == ProofStatus.APPROVED;
+    }
 }

--- a/src/main/java/me/jinjjahalgae/domain/proof/usecase/process/ProcessProofStatusUseCaseImpl.java
+++ b/src/main/java/me/jinjjahalgae/domain/proof/usecase/process/ProcessProofStatusUseCaseImpl.java
@@ -8,11 +8,11 @@ import me.jinjjahalgae.domain.contract.repository.ContractRepository;
 import me.jinjjahalgae.domain.feedback.entity.Feedback;
 import me.jinjjahalgae.domain.feedback.repository.FeedbackRepository;
 import me.jinjjahalgae.domain.notification.enums.NotificationType;
-import me.jinjjahalgae.domain.notification.usecase.create.CreateNotificationUseCase;
-import me.jinjjahalgae.domain.notification.usecase.create.dto.NotificationCreateRequest;
+import me.jinjjahalgae.domain.notification.usecase.listener.event.NotificationEvent;
 import me.jinjjahalgae.domain.proof.entities.Proof;
 import me.jinjjahalgae.domain.proof.repository.ProofRepository;
 import me.jinjjahalgae.global.exception.ErrorCode;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,7 +26,7 @@ public class ProcessProofStatusUseCaseImpl implements ProcessProofStatusUseCase 
     private final FeedbackRepository feedbackRepository;
     private final ContractRepository contractRepository;
 
-    private final CreateNotificationUseCase createNotificationUseCase;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     @Transactional
@@ -50,9 +50,9 @@ public class ProcessProofStatusUseCaseImpl implements ProcessProofStatusUseCase 
 
             // 인증 계산 결과에 따른 알림 전송
             if(proof.isApproved()) {
-                createNotificationUseCase.execute(new NotificationCreateRequest(NotificationType.PROOF_ACCEPTED, contract.getId(), contract.getUser().getId()));
+                eventPublisher.publishEvent(new NotificationEvent(NotificationType.PROOF_ACCEPTED, contract.getId(), contract.getUser().getId()));
             }else{
-                createNotificationUseCase.execute(new NotificationCreateRequest(NotificationType.PROOF_REJECTED, contract.getId(), contract.getUser().getId()));
+                eventPublisher.publishEvent(new NotificationEvent(NotificationType.PROOF_REJECTED, contract.getId(), contract.getUser().getId()));
             }
 
             // "단건 계약일 때" 인증 결과에 따라 즉시 계약 상태 처리 + 알림 전송
@@ -60,11 +60,11 @@ public class ProcessProofStatusUseCaseImpl implements ProcessProofStatusUseCase 
                 if(proof.isApproved()) {
                     contract.complete();
 
-                    createNotificationUseCase.execute(new NotificationCreateRequest(NotificationType.CONTRACT_ENDED_SUCCESS, contract.getId(), contract.getUser().getId()));
+                    eventPublisher.publishEvent(new NotificationEvent(NotificationType.CONTRACT_ENDED_SUCCESS, contract.getId(), contract.getUser().getId()));
                 } else {
                     contract.fail();
-
-                    createNotificationUseCase.execute(new NotificationCreateRequest(NotificationType.CONTRACT_ENDED_FAIL, contract.getId(), contract.getUser().getId()));
+                    
+                    eventPublisher.publishEvent(new NotificationEvent(NotificationType.CONTRACT_ENDED_FAIL, contract.getId(), contract.getUser().getId()));
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/me/jinjjahalgae/domain/proof/usecase/process/ProcessProofStatusUseCaseImpl.java
+++ b/src/main/java/me/jinjjahalgae/domain/proof/usecase/process/ProcessProofStatusUseCaseImpl.java
@@ -2,8 +2,14 @@ package me.jinjjahalgae.domain.proof.usecase.process;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import me.jinjjahalgae.domain.contract.entity.Contract;
+import me.jinjjahalgae.domain.contract.enums.ContractStatus;
+import me.jinjjahalgae.domain.contract.repository.ContractRepository;
 import me.jinjjahalgae.domain.feedback.entity.Feedback;
 import me.jinjjahalgae.domain.feedback.repository.FeedbackRepository;
+import me.jinjjahalgae.domain.notification.enums.NotificationType;
+import me.jinjjahalgae.domain.notification.usecase.create.CreateNotificationUseCase;
+import me.jinjjahalgae.domain.notification.usecase.create.dto.NotificationCreateRequest;
 import me.jinjjahalgae.domain.proof.entities.Proof;
 import me.jinjjahalgae.domain.proof.repository.ProofRepository;
 import me.jinjjahalgae.global.exception.ErrorCode;
@@ -18,7 +24,9 @@ import java.util.List;
 public class ProcessProofStatusUseCaseImpl implements ProcessProofStatusUseCase {
     private final ProofRepository proofRepository;
     private final FeedbackRepository feedbackRepository;
+    private final ContractRepository contractRepository;
 
+    private final CreateNotificationUseCase createNotificationUseCase;
 
     @Override
     @Transactional
@@ -29,13 +37,36 @@ public class ProcessProofStatusUseCaseImpl implements ProcessProofStatusUseCase 
                     ErrorCode.PROOF_NOT_FOUND.domainException("인증을 찾을 수 없음: " + proofId)
             );
 
+            // proof의 contractId로 contract 조회
+            Contract contract = contractRepository.findById(proof.getContractId()).orElseThrow(()->
+                    ErrorCode.CONTRACT_NOT_FOUND.domainException("계약을 찾을 수 없음: " + proof.getContractId())
+            );
+
             // 인증에 관련된 피드백들을 가져와서
             List<Feedback> feedbacks = feedbackRepository.findByProofId(proof.getId());
 
             // 계산해서 처리
             proof.processFeedbackResult(feedbacks);
 
-            // TODO 인증 처리 완료 알림 이벤트 발행
+            // 인증 계산 결과에 따른 알림 전송
+            if(proof.isApproved()) {
+                createNotificationUseCase.execute(new NotificationCreateRequest(NotificationType.PROOF_ACCEPTED, contract.getId(), contract.getUser().getId()));
+            }else{
+                createNotificationUseCase.execute(new NotificationCreateRequest(NotificationType.PROOF_REJECTED, contract.getId(), contract.getUser().getId()));
+            }
+
+            // "단건 계약일 때" 인증 결과에 따라 즉시 계약 상태 처리 + 알림 전송
+            if (contract.isOneOff() && contract.getStatus() == ContractStatus.IN_PROGRESS) {
+                if(proof.isApproved()) {
+                    contract.complete();
+
+                    createNotificationUseCase.execute(new NotificationCreateRequest(NotificationType.CONTRACT_ENDED_SUCCESS, contract.getId(), contract.getUser().getId()));
+                } else {
+                    contract.fail();
+
+                    createNotificationUseCase.execute(new NotificationCreateRequest(NotificationType.CONTRACT_ENDED_FAIL, contract.getId(), contract.getUser().getId()));
+                }
+            }
         } catch (Exception e) {
             log.error("인증 처리 중 오류 발생: {}", e.getMessage(), e);
         }


### PR DESCRIPTION
## #️⃣ Issue Number
#81 

## 📝 요약(Summary)
- `ContractRepository`
  - 치연님이 구현하셨던 "시작일, 종료일로 대기중 계약 목록 조회하는 쿼리"에 단일인지 아닌지 검증하는 구현부 추가
  - 단일 계약 구현에 필요한 쿼리메서드 3개 추가
    - 생성된 지 24시간이 지났고 서명한 감독자가 한 명도 없고 PENDING 상태의 단일 계약 목록 조회 (자동 단일 계약 삭제를 위함)
    - 시작된 지 24시간이 지났고 인증이 하나 이상 존재하고 피드백이 하나라도 없는 진행중인 단일 계약 목록 조회 (자동 계약 성공 처리를 위함)
    - 시작된 지 24시간이 지났고 인증이 하나도 없고 진행중인 단일 계약 목록 조회 (자동 계약 실패 처리를 위함)

- `ContractScheduler` 구현 수정(치연님 구현)
  - `findByStatusAndStartDateOn` 을  -> `findByStatusAndStartDateOnAndOneOff` 로 수정 (단일이 아닌 계약만 찾아서 처리하도록)

- `OneOffContractScheduler` (새롭게 구현) - 매 5분마다 실행됨
  - 단일 계약 24시간 체크 로직 추가
  - 단일 계약 서명검증 로직 추가

- `EndOneOffContractUseCase` 추가
- `EndOneOffContractUseCaseImpl` 추가
  - 단일 계약(oneOff=true)이 시작되고 24시간이 지났는지 확인하고 계약 상태를 결정


- `VerifyOffContractUseCase` 추가
- `VerifyOffContractUseCaseImpl` 추가
  - 단일 계약(oneOff=true)의 서명을 검증하고 계약이 생성된 후 24시간 내에 1명이라도 감독자가 서명하지 않은 계약은 삭제

- `CreateSupervisorParticipationUseCaseImpl` 구현 수정 (치연님 구현)
  - 만약 단발성 계약이면 바로 시작처리 하는 로직 추가

- `Proof` 헬퍼메서드 추가 (광현님 구현)
  - isApporved() 메서드 추가

- `ProcessProofStatusUseCaseImpl` 구현 추가
  - 인증 처리 결과 알림 발송 로직 추가
  - 단일 계약일 때 인증 결과에 따라 즉시 계약 상태 처리되는 로직추가 + 알림 전송 로직 추가
  
- `CreateFeedbackUseCaseImpl` 알림 발행 구현 추가

- 알림 발송 로직을 이벤트를 발행하는 방식으로 수정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

-   [x] 새로운 기능 추가
-   [ ] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
`EndOneOffContractUseCaseImpl` 에서 벌크 처리를 하지 않은 이유는 알림 보내는 로직도 있을 뿐더러 하루 단위로 계약들이 처리될 거라 많은 양의 계약을 처리하지 않아도 될 것 같아서 foreach로 갔습니다

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
-   [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
-   [x] 릴리즈 노트를 갱신했습니다.
