### PR TITLE
refactor(scheduler-contract): 계약 시작시 삭제된 계약의 알림은 usecaes로 바로 보내도록 수정

### DIFF
--- a/src/main/java/me/jinjjahalgae/domain/contract/usecase/process/StartContractsUseCaseImpl.java
+++ b/src/main/java/me/jinjjahalgae/domain/contract/usecase/process/StartContractsUseCaseImpl.java
@@ -5,18 +5,16 @@ import me.jinjjahalgae.domain.contract.entity.Contract;
 import me.jinjjahalgae.domain.contract.enums.ContractStatus;
 import me.jinjjahalgae.domain.contract.repository.ContractRepository;
 import me.jinjjahalgae.domain.notification.enums.NotificationType;
+import me.jinjjahalgae.domain.notification.usecase.create.CreateNotificationUseCase;
+import me.jinjjahalgae.domain.notification.usecase.create.dto.NotificationCreateRequest;
 import me.jinjjahalgae.domain.notification.usecase.listener.event.NotificationEvent;
-import me.jinjjahalgae.domain.proof.repository.ProofRepository;
 import me.jinjjahalgae.global.storage.redis.usecase.invite.bulk.BulkDeleteInviteInfoUseCase;
 import me.jinjjahalgae.global.storage.redis.usecase.invite.get.GetJoinedSupervisorsUseCase;
-import me.jinjjahalgae.global.util.UtcDateTimeUtil;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -29,6 +27,7 @@ public class StartContractsUseCaseImpl implements StartContractsUseCase {
     private final BulkDeleteInviteInfoUseCase bulkdeleteInviteInfoUseCase;
     private final GetJoinedSupervisorsUseCase getJoinedSupervisorsUseCase;
     private final ApplicationEventPublisher eventPublisher;
+    private final CreateNotificationUseCase createNotificationUseCase;
 
     @Override
     @Transactional
@@ -64,7 +63,7 @@ public class StartContractsUseCaseImpl implements StartContractsUseCase {
             contractRepository.deleteAll(deleteContracts);
 
             deleteContracts.forEach(contract ->
-                    eventPublisher.publishEvent(new NotificationEvent(
+                    createNotificationUseCase.execute(new NotificationCreateRequest(
                             NotificationType.CONTRACT_AUTO_DELETED,
                             contract.getId(),
                             contract.getUser().getId()


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 계약 삭제시 트랜젝션이 분리되어 원래 계약의 정보를 불러오지 못해 이벤트로는 알림을 보내지 못하는 문제가 있어서 usecase로 바로 보내도록 수정했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

-   [ ] 새로운 기능 추가
-   [ ] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [x] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
-   [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
-   [ ] 릴리즈 노트를 갱신했습니다.
